### PR TITLE
Use symbols as well as colors to denote results

### DIFF
--- a/cwrstatus/static/css/base.css
+++ b/cwrstatus/static/css/base.css
@@ -21,7 +21,6 @@
 
 .test-result, .test-result:before, .test-result:after {
     padding: 0;
-    border-radius: 12px;
     height: 12px;
     min-width: 12px;
     display: inline-block;
@@ -29,17 +28,14 @@
 
 .pass, .pass:before, .pass:after {
     color: #18A900;
-    background-color: #18A900;
 }
 
 .fail, .fail:before, .fail:after {
     color: #ff3300;
-    background-color: #ff3300;
 }
 
 .no-result, .no-result:before, .no-result:after {
     color: #ccc;
-    background-color: #ccc;
 }
 
 .last-result {

--- a/cwrstatus/templates/bundle.html
+++ b/cwrstatus/templates/bundle.html
@@ -87,13 +87,13 @@
 
 {% macro display_status_img(value, size='30px') -%}
     {% if value == 'PASS' or value == 'All Passed' %}
-        <span class="test-result pass"></span>
+        <span class="test-result pass">&#x2714;</span>
     {% elif value == 'FAIL' or value == 'All Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% elif value == 'Some Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% else %}
-        <span class="test-result no-result"></span>
+        <span class="test-result no-result">&#x26AB;</span>
     {% endif %}
 {%- endmacro %}
 

--- a/cwrstatus/templates/bundles.html
+++ b/cwrstatus/templates/bundles.html
@@ -6,13 +6,13 @@
 
 {% macro display_status_img(value, size='30px') -%}
     {% if value == 'PASS' or value == 'All Passed' %}
-        <span class="test-result pass"></span>
+        <span class="test-result pass">&#x2714;</span>
     {% elif value == 'FAIL' or value == 'All Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% elif value == 'Some Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% else %}
-        <span class="test-result no-result"></span>
+        <span class="test-result no-result">&#x26AB;</span>
     {% endif %}
 {%- endmacro %}
 

--- a/cwrstatus/templates/recent.html
+++ b/cwrstatus/templates/recent.html
@@ -6,13 +6,13 @@
 
 {% macro display_status_img(value, size='30px') -%}
     {% if value == 'PASS' or value == 'All Passed' %}
-        <span class="test-result pass"></span>
+        <span class="test-result pass">&#x2714;</span>
     {% elif value == 'FAIL' or value == 'All Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% elif value == 'Some Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% else %}
-        <span class="test-result no-result"></span>
+        <span class="test-result no-result">&#x26AB;</span>
     {% endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
This fixes #12 by providing non-color cues for the result to enable color-blind users to distinguish them.

(See juju-solutions/cloud-weather-report#39 for an example of what this should look like.)