### PR TITLE
Added test_id field.

### DIFF
--- a/cwrstatus/import_data.py
+++ b/cwrstatus/import_data.py
@@ -5,6 +5,7 @@ from cwrstatus.datastore import (
     S3,
 )
 from cwrstatus.config import app
+import utils
 
 
 def from_s3(overwrite=False):
@@ -103,6 +104,7 @@ def make_doc(build_info, test, job_name, key, artifacts, svg_path):
     doc['artifacts'] = artifacts
     doc['svg_path'] = svg_path
     doc['etag'] = key.etag
+    doc['test_id'] = test.get('test_id', utils.generate_test_id())
     return doc
 
 

--- a/cwrstatus/tests/test_import_data.py
+++ b/cwrstatus/tests/test_import_data.py
@@ -80,7 +80,7 @@ class TestImportData(RequestTest):
 
     def test_make_doc(self):
         build_info = make_build_info()
-        test = {'date': '1'}
+        test = {'date': '1', 'test_id': '1234'}
         job_name = 'cwr-test'
         artifacts = ['foo', 'bar']
         svg_path = 'path/to/svg'
@@ -101,6 +101,7 @@ class TestImportData(RequestTest):
             'etag': key.etag,
             'artifacts': artifacts,
             'svg_path': 'path/to/svg',
+            'test_id': '1234',
         }
         self.assertEqual(doc, expected)
 

--- a/cwrstatus/utils.py
+++ b/cwrstatus/utils.py
@@ -1,5 +1,10 @@
 from datetime import datetime
+import uuid
 
 
 def get_current_utc_time():
     return datetime.utcnow().isoformat()
+
+
+def generate_test_id():
+    return uuid.uuid4().hex

--- a/scripts/restart.bash
+++ b/scripts/restart.bash
@@ -1,0 +1,2 @@
+pkill gunicorn
+./scripts/start.bash


### PR DESCRIPTION
Added test_id field. A bundle test on different clouds will have the same test_id and this field will be used to group these tests together during reporting. 