### PR TITLE
Use Chartjs for displaying benchmarking charts.

### DIFF
--- a/cwrstatus/bundle.py
+++ b/cwrstatus/bundle.py
@@ -54,41 +54,98 @@ class Bundle:
     def test_result(self):
         return self.test
 
-    def generate_chart_data(self):
-        """Generate benchmarks by joining the past and current benchmark data.
+    @staticmethod
+    def calculate_avg_benchmark(datasets):
+        for dataset in datasets:
+            data = [float(x) for x in dataset['data'] if x]
+            avg = sum(data) / float(len(data))
+            dataset['label'] = '{} ({:.2f})'.format(dataset['label'], avg)
 
-        :rtype: dict
-        """
-        past_results = list(self.get_past_tests())
-        title = 'No data'
-        series = []
-        yaxis_tilte = ''
-        for test_result in self.test.get('results'):
-            data = []
-            benchmarks = test_result.get('benchmarks')
-            if benchmarks:
-                past_ben = self.get_past_benchmarks(
-                        test_result.get('provider_name'), past_results)
-                data = [benchmarks[0].values()[0]['value']]
-                if past_ben:
-                    data = past_ben + data
-                yaxis_tilte = benchmarks[0].values()[0].get('units')
-                title = benchmarks[0].keys()[0]
-            series.append(
-                {
-                    'name': test_result.get('provider_name'),
-                    'data':  map(float, data) if data else []
-                }
-            )
-        chart = {
+    def generate_chart_data(self):
+        ds = Datastore()
+        test_ids = list(ds.get_test_ids(
+            bundle=self.name, date=self.bundle.get('date')))
+        if test_ids:
+            test_ids.reverse()
+        provider_names = self.get_provider_names(test_ids)
+        datasets = self._create_initial_datasets(provider_names)
+        title = None
+        benchmark_data_available = False
+        for test_id in test_ids:
+            tests = ds.get({'test_id': test_id['_id']})
+            for provider_name in provider_names:
+                data = self._get_dataset(datasets, provider_name)
+                data['data'].append(None)
+            for test in tests:
+                test = test.get('test') or {}
+                for result in test.get('results', []):
+                    provider_name = result.get('provider_name')
+                    data = self._get_dataset(datasets, provider_name)
+                    benchmarks = result.get('benchmarks')
+                    if not benchmarks:
+                        continue
+                    data['data'][-1] = benchmarks[0].values()[0]['value']
+                    title = benchmarks[0].keys()[0]
+                    benchmark_data_available = True
+        if not benchmark_data_available:
+            return None
+        self.calculate_avg_benchmark(datasets)
+        title = "{} Benchmark Chart".format(title.title())
+        chart_data = {
+            'labels': [x['_id'][-5:] for x in test_ids],
+            'datasets': datasets,
             'title': title,
-            'yaxis_title': yaxis_tilte,
-            'series': series
         }
-        return json.dumps(chart)
+        return json.dumps(chart_data)
+
+    @staticmethod
+    def _create_initial_datasets(provider_names):
+        border_colors = ['#4B98D9', '#56CE65', '#FFA342', '#AA54AD', '#DC654B',
+                         '#E66BB3']
+        datasets = []
+        for provider_name, color in zip(provider_names, border_colors):
+            data = {
+                'label': provider_name,
+                'fill': False,
+                'borderColor': color,
+                'borderWidth': 2,
+                'backgroundColor': color,
+                'lineTension': 0.1,
+                'data': [],
+            }
+            datasets.append(data)
+        return datasets
+
+    @staticmethod
+    def _get_dataset(datasets, provider_name):
+        for data in datasets:
+            if provider_name == data['label']:
+                return data
+        return None
 
     def svg_path(self):
         svg_path = self.bundle.get('svg_path')
         if not svg_path:
             return 'No Image'
         return 'http://data.vapour.ws/cwr/{}'.format(svg_path)
+
+    @staticmethod
+    def get_provider_names(test_ids):
+        ds = Datastore()
+        provider_names = []
+        for result in Bundle.iter_results_by_test_ids(test_ids, ds):
+            provider_name = result.get('provider_name')
+            if not provider_name:
+                continue
+            if provider_name not in provider_names:
+                provider_names.append(provider_name)
+        return sorted(provider_names)
+
+    @staticmethod
+    def iter_results_by_test_ids(test_ids, ds):
+        for test_id in test_ids:
+            tests = ds.get({'test_id': test_id['_id']})
+            for test in tests:
+                test = test.get('test') or {}
+                for result in test.get('results', []):
+                    yield result

--- a/cwrstatus/static/css/base.css
+++ b/cwrstatus/static/css/base.css
@@ -96,3 +96,12 @@
     border-bottom: 1px solid #aaa;
     color:#888
 }
+
+.chart-title{
+    font-size: 18px;
+    font-family: "Helvetica Neue", Helvetica, Arial, "sans-serif";
+    color: #666;
+    font-weight: bold;
+    padding: 10px;
+    text-align: center;
+}

--- a/cwrstatus/templates/bundle.html
+++ b/cwrstatus/templates/bundle.html
@@ -7,6 +7,7 @@
 {% block head %}
 
         <script type='text/javascript' src='/static/js/jquery.min.js'></script>
+        <script type='text/javascript' src='/static/js/Chartjs/dist/Chart.js'></script>
 
     <script type='text/javascript'>
         function hide_rows(name) {
@@ -29,8 +30,26 @@
             $(w.document.body).html(html);
         }
 
+        function display_chart(chart_data) {
+            var ctx = document.getElementById("benchmark-chart").getContext("2d");
+            var data = JSON.parse(chart_data);
+            new Chart(ctx, {
+                type: "bar",
+                data: {
+                    labels: data['labels'],
+                    datasets: data['datasets']
+                },
+                options: {
+                    title: {
+                        display: true,
+                        text: data["title"],
+                        fontSize: 18
+                    },
+                    responsive: true
+                }
+            });
+        }
     </script>
-
 
 {% endblock %}
 
@@ -135,11 +154,16 @@
 
     <div class="row">
         <div class="twelve-col">
-            <div id="chart-container" class="chart">
-                <div>
+            {% if chart_data %}
+                <canvas id="benchmark-chart" height="200"></canvas>
+                <script> display_chart('{{ chart_data|safe }}');</script>
+            {% else %}
+                <div class="chart-title">
+                    Benchmark Data Not Available
                 </div>
-            </div>
+            {% endif %}
         </div>
     </div>
+
 {% endblock %}
 


### PR DESCRIPTION
In addition to using Charjs, the PR also makes the following improvements:

- Latest benchmark results are displayed on the right side of the chart (previously, it was on left).
- Benchmark results are grouped by test id.
- Updated the code to calculate the average benchmark data per cloud. Now, averages are displayed on to the chart legend. 
- Updated to use bar instead of line chart. When a test fails and doesn't generate benchmark data for a specific cloud, line charts generate visually distracting chart. See the following images:

Line chart:
![sc 1](https://cloud.githubusercontent.com/assets/1581316/16756054/3e428324-47b7-11e6-85f5-95cc2b13e038.png)

Bar chart:
![bar](https://cloud.githubusercontent.com/assets/1581316/16756228/9a801a74-47b8-11e6-9492-717174723dd4.png)


