### PR TITLE
Created API to get access to the test result artifacts.

### DIFF
--- a/cwrstatus/config.py
+++ b/cwrstatus/config.py
@@ -33,3 +33,4 @@ app = Flask('cwr')
 init()
 ds = PyMongo(app)   # Data store
 PAGE_LIMIT = 20
+DATA_PROXY = 'http://data.vapour.ws/cwr'

--- a/cwrstatus/main.py
+++ b/cwrstatus/main.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import os
 
 from flask import (
+    jsonify,
     redirect,
     render_template,
     request,
@@ -18,11 +19,17 @@ from cwrstatus.config import (
 from cwrstatus.datastore import Datastore
 from cwrstatus.pagination import Pagination
 from cwrstatus.import_data import from_s3
+from cwrstatus.utils import generate_json_results
 
 
 @app.route('/')
 def index():
     return redirect(url_for('recent'))
+
+
+@app.route('/.json')
+def index_json():
+    return redirect(url_for('recent_json'))
 
 
 @app.route('/recent', defaults={'page': 1})
@@ -31,19 +38,34 @@ def recent(page):
     return get_recent_bundles(page)
 
 
+@app.route('/recent.json', defaults={'page': 1})
+@app.route('/recent.json/page/<int:page>')
+def recent_json(page):
+    limit = PAGE_LIMIT
+    bundles = get_recent_test_result(page, limit)
+    results = generate_json_results(bundles)
+    return jsonify(results)
+
+
 @app.route('/recent/<bundle>', defaults={'page': 1})
 @app.route('/recent/<bundle>/page/<int:page>')
 def recent_by_bundle(bundle, page):
     return get_recent_bundles(page, bundle=bundle)
 
 
-def get_recent_bundles(page, bundle=None):
-    ds = Datastore()
+@app.route('/recent/<bundle>.json', defaults={'page': 1})
+@app.route('/recent/<bundle>.json/page/<int:page>')
+def recent_test_result_by_bundle_json(bundle, page):
     limit = PAGE_LIMIT
-    skip = limit * (abs(page) - 1)
-    test_ids = ds.get_test_ids(bundle=bundle, limit=limit, skip=skip)
+    bundles = get_recent_test_result(page, limit, bundle=bundle)
+    results = generate_json_results(bundles)
+    return jsonify(results)
+
+
+def get_recent_bundles(page, bundle=None):
+    limit = PAGE_LIMIT
+    cwr_results = get_recent_test_result(page, limit, bundle)
     bundle_title = 'Recent tests'
-    cwr_results = get_results_by_test_ids(test_ids)
     total_count = 0 if len(cwr_results) < limit else 999
     pagination = Pagination(
         page=page, total_count=total_count, limit_per_page=limit,
@@ -53,9 +75,17 @@ def get_recent_bundles(page, bundle=None):
         pagination=pagination)
 
 
-@app.route('/bundle', defaults={'key': None})
-@app.route('/bundle/<key>')
-def bundle_view(key=None):
+def get_recent_test_result(page, limit, bundle=None):
+    ds = Datastore()
+    skip = limit * (abs(page) - 1)
+    test_ids = ds.get_test_ids(bundle=bundle, limit=limit, skip=skip)
+    cwr_results = get_results_by_test_ids(test_ids)
+    return cwr_results
+
+
+@app.route('/test', defaults={'key': None})
+@app.route('/test/<key>')
+def result_by_test_id(key=None):
     if not key:
         return render_template('404.html', e='Bundle not found.'), 404
     test_id = {}
@@ -74,6 +104,14 @@ def bundle_view(key=None):
     return render_template(
         'bundle.html', bundle_name=bundle_name, results=results,
         svg_path=svg_path, history=history, chart_data=chart_data)
+
+
+@app.route('/test/<test_id>.json')
+def result_by_test_id_json(test_id=None):
+    test_id = {'_id': test_id}
+    results = get_results_by_test_id(test_id)
+    results = generate_json_results([results])
+    return jsonify(results)
 
 
 def get_results_by_test_id(test_id, ds=None):
@@ -126,7 +164,7 @@ def humanize_date_filter(value, time_format=None):
 
 @app.errorhandler(404)
 def page_not_found(e):
-    render_template('404.html', e='Page not found'), 404
+    return render_template('404.html', e='Page not found'), 404
 
 
 @app.route('/favicon.ico')

--- a/cwrstatus/main.py
+++ b/cwrstatus/main.py
@@ -83,6 +83,8 @@ def get_recent_test_result(page, limit, bundle=None):
     return cwr_results
 
 
+@app.route('/bundle', defaults={'key': None})
+@app.route('/bundle/<key>')
 @app.route('/test', defaults={'key': None})
 @app.route('/test/<key>')
 def result_by_test_id(key=None):

--- a/cwrstatus/templates/base.html
+++ b/cwrstatus/templates/base.html
@@ -3,10 +3,7 @@
 <head>
         <meta charset="UTF-8">
         <title>{{ title }}</title>
-        <!--link rel="stylesheet" type="text/css" media="screen" href="/static/css/ubuntu-styles.css" -->
         <link rel="stylesheet" type="text/css" media="screen" href="https://assets.ubuntu.com/v1/vanilla-framework-version-0.0.65.min.css">
-        <!-- link rel="stylesheet" type="text/css" media="all"
-              href="http://assets.ubuntu.com/sites/guidelines/css/latest/ubuntu-styles.css"/ -->
         <link rel="stylesheet" type="text/css" href="/static/css/base.css" >
 
     {% block head %}

--- a/cwrstatus/templates/bundle.html
+++ b/cwrstatus/templates/bundle.html
@@ -75,7 +75,9 @@
 
 
                 {% for result in results['results'] %}
+
                     {% set rowloop = loop %}
+
                     <tr onclick="toggle_rows('t{{ rowloop.index }}');" class="result">
                         <td colspan="2" class="cloud-list">
                             <a href="javascript:;" title="{{ result['build_id'] }}">{{ result["provider_name"] }}</a>
@@ -96,6 +98,8 @@
 
                     {% for group in result['tests']|groupby('suite') %}
 
+                        {% set rowloop2 = loop %}
+
                         {%  if group.grouper %}
                             <tr class="t{{ rowloop.index }} hide-it suite-title">
                                 <td colspan="5">
@@ -106,6 +110,7 @@
 
                         {% for test in group.list %}
 
+
                             {% if total_time.append(test.get('duration', 0)|float ) %} {% endif %}
 
                             <script>
@@ -113,7 +118,7 @@
                             </script>
 
                             <tr class="t{{ rowloop.index }} hide-it">
-                                <td colspan="2" class="" onclick="open_in_new_window('log-{{ rowloop.index }}{{ loop.index }}')">
+                                <td colspan="2" class="" onclick="open_in_new_window('log-{{ rowloop.index }}{{ rowloop2.index }}{{ loop.index }}')">
                                     <a href="javascript:;">
                                         {{ test["name"] }}
                                     </a>
@@ -125,7 +130,7 @@
                                     {{ display_status_img(test["result"]) }}
                                 </td>
                             </tr>
-                            <tr class="output{{ rowloop.index }}{{ loop.index }} hide-it" id="log-{{ rowloop.index }}{{ loop.index }}">
+                            <tr class="output{{ rowloop.index }}{{ rowloop2.index }}{{ loop.index }} hide-it" id="log-{{ rowloop.index }}{{ rowloop2.index }}{{ loop.index }}">
                                 <td colspan="5">
                                     <textarea cols="7" disabled>
                                         {{ test.get("output", "no output")|safe }}

--- a/cwrstatus/templates/recent.html
+++ b/cwrstatus/templates/recent.html
@@ -32,7 +32,7 @@
                         {{ grouped_tests[0]['bundle_name'] }}
                     </td>
                     <td>
-                        <a href="{{ url_for('bundle_view', key=grouped_tests[0]['test_id']) }}">
+                        <a href="{{ url_for('result_by_test_id', key=grouped_tests[0]['test_id']) }}">
                             {{ grouped_tests[0]['test']['date'] | humanize_date }}
                         </a>
                     </td>
@@ -43,7 +43,7 @@
 
                             {% for outcome in tests['test']['results'] %}
 
-                                <table class="outcome" onclick="window.location='{{ url_for('bundle_view', key=grouped_tests[0]['test_id']) }}'">
+                                <table class="outcome" onclick="window.location='{{ url_for('result_by_test_id', key=grouped_tests[0]['test_id']) }}'">
                                     <tr>
                                         <td>
                                             {{ outcome.get("provider_name") }}

--- a/cwrstatus/tests/test_bundle.py
+++ b/cwrstatus/tests/test_bundle.py
@@ -63,7 +63,7 @@ class TestBundle(DatastoreTest):
                     {
                         "borderColor": "#4B98D9",
                         "lineTension": 0.1,
-                        "label": "AWS (2.00)",
+                        "label": "AWS (2.00 avg  1.00 sd)",
                         "borderWidth": 2,
                         "backgroundColor": "#4B98D9",
                         "data": [1.0, 3.0],
@@ -72,14 +72,15 @@ class TestBundle(DatastoreTest):
                     {
                         "borderColor": "#56CE65",
                         "lineTension": 0.1,
-                        "label": "Azure (2.00)",
+                        "label": "Azure (2.00 avg  0.00 sd)",
                         "borderWidth": 2,
                         "backgroundColor": "#56CE65",
                         "data": [2, None],
                         "fill": False,
                     }
                 ],
-                "title": "Terasort Benchmark Chart"
+                "title": "Terasort Benchmark Chart  (Units: secs  "
+                         "Direction: asc)"
             })
         self.assertEqual(chart, expected)
 

--- a/cwrstatus/tests/test_import_data.py
+++ b/cwrstatus/tests/test_import_data.py
@@ -84,9 +84,12 @@ class TestImportData(RequestTest):
         job_name = 'cwr-test'
         artifacts = ['foo', 'bar']
         svg_path = 'path/to/svg'
+        html_path = 'example.com/html'
+        json_path = 'exaple.com/json'
         key = FakeKey(name='foo')
         doc = import_data.make_doc(
-            build_info, test, job_name, key, artifacts, svg_path)
+            build_info, test, job_name, key, artifacts, svg_path, html_path,
+            json_path)
         expected = {
             'bundle_name': 'git',
             'test_plan': 'git.yaml',
@@ -102,6 +105,8 @@ class TestImportData(RequestTest):
             'artifacts': artifacts,
             'svg_path': 'path/to/svg',
             'test_id': '1234',
+            'html_path': html_path,
+            'json_path': json_path,
         }
         self.assertEqual(doc, expected)
 
@@ -148,7 +153,8 @@ class TestImportDataDs(DatastoreTest):
         test = {'date': '1'}
         job_name = 'cwr-test'
         key = FakeKey(name='cwr/cwr-test/1/1234-result-results.json')
-        doc = import_data.make_doc(build_info, test, job_name, key, None, None)
+        doc = import_data.make_doc(build_info, test, job_name, key, None, None,
+                                   None, None)
         self.ds.db.cwr.update(
             {'_id': import_data._get_id(key)}, doc, upsert=True)
         needs_update = import_data.doc_needs_update(key)

--- a/cwrstatus/tests/test_utils.py
+++ b/cwrstatus/tests/test_utils.py
@@ -1,0 +1,215 @@
+from cwrstatus.utils import generate_json_results
+
+from cwrstatus.testing import (
+    TestCase
+)
+
+
+class TestGenerateJsonResults(TestCase):
+    def test_generate_json_results(self):
+        results = []
+        results.append(make_results())
+        results = generate_json_results([results])
+        expected = [{
+            'bundle_name': 'wiki-simple',
+            'tests': [
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'All Passed',
+                            'provider_name': 'AWS'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-log-'
+                                 'bundle_wiki_simple-1-result.html'
+                }
+            ],
+            'test_id': '1234'
+        }]
+        self.assertEqual(results, expected)
+
+    def test_generate_json_results_mutli_test(self):
+        results = []
+        results.append(make_results())
+        results.append(make_results(cloud='GCE'))
+        results.append(make_results(cloud='Azure', outcome='Some Failed'))
+        results = generate_json_results([results])
+        expected = [{
+            'bundle_name': 'wiki-simple',
+            'tests': [
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'All Passed',
+                            'provider_name': 'AWS'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-'
+                                 'log-bundle_wiki_simple-1-result.html'
+                },
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'All Passed',
+                            'provider_name': 'GCE'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-log-'
+                                 'bundle_wiki_simple-1-result.html'
+                },
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'Some Failed',
+                            'provider_name': 'Azure'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-log-'
+                                 'bundle_wiki_simple-1-result.html'
+                }
+            ],
+            'test_id': '1234'
+        }]
+        self.assertEqual(results, expected)
+
+    def test_generate_json_results_mutli_tests_multi_test_ids(self):
+        results = []
+        results.append(make_results())
+        results.append(make_results(cloud='GCE'))
+        result2 = make_results(
+            test_id='7890', cloud='Azure', outcome='Some Failed',
+            bundle_name='hadoop')
+        results = [results, [result2]]
+        results = generate_json_results(results)
+        expected = [{
+            'bundle_name': 'wiki-simple',
+            'tests': [
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'All Passed',
+                            'provider_name': 'AWS'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-log-'
+                                 'bundle_wiki_simple-1-result.html'
+                },
+                {
+                    'date': '2016-07-13T01:20:19',
+                    'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-log-'
+                                 'bundle_wiki_simple-3-result.json',
+                    'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-log-'
+                                'bundle_wiki_simple-2-result.svg',
+                    'results': [
+                        {
+                            'test_outcome': 'All Passed',
+                            'provider_name': 'GCE'
+                        }
+                    ],
+                    'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-log-'
+                                 'bundle_wiki_simple-1-result.html'
+                }
+            ],
+            'test_id': '1234'
+        },
+            {
+                'bundle_name': 'hadoop',
+                'tests': [
+                    {
+                        'date': '2016-07-13T01:20:19',
+                        'json_path': 'http://data.vapour.ws/cwr/cwr-azure/3/3-'
+                                     'log-bundle_wiki_simple-3-result.json',
+                        'svg_path': 'http://data.vapour.ws/cwr/cwr-azure/2/2-'
+                                    'log-bundle_wiki_simple-2-result.svg',
+                        'results': [
+                            {
+                                'test_outcome': 'Some Failed',
+                                'provider_name': 'Azure'
+                            }
+                        ],
+                        'html_path': 'http://data.vapour.ws/cwr/cwr-azure/1/1-'
+                                     'log-bundle_wiki_simple-1-result.html'
+                    }
+                ],
+                'test_id': '7890'
+            }]
+        self.assertEqual(results, expected)
+
+
+def make_results(test_id='1234', cloud='AWS', outcome='All Passed',
+                 bundle_name='wiki-simple'):
+    return {
+        "_id": "cwr-azure-83",
+        "test_plan": "/path/wiki-simple.yaml",
+        "artifacts": [
+            "bundle_wiki_simple-1-result.html",
+            "bundle_wiki_simple-2-result.json",
+            "bundle_wiki_simple-3-result.svg"
+        ],
+        "_updated_on": "2016-07-13T01:57:52.930859",
+        "html_path": "cwr-azure/1/1-log-bundle_wiki_simple-1-result.html",
+        "controllers": "charm-testing-azure",
+        "test": {
+            "results": [{
+                "info": {},
+                "test_outcome": outcome,
+                "provider_name": cloud,
+                "tests": [{
+                    "duration": "1",
+                    "output": "Good",
+                    "suite": "cs:trusty/mysql-55",
+                    "result": "PASS",
+                    "name": "charm-proof"
+                }, {
+                    "duration": "12",
+                    "output": "",
+                    "suite": "bundle",
+                    "result": "PASS",
+                    "name": "charm-proof"
+                }],
+                "benchmarks": []
+            }
+            ],
+            "bundle": {},
+            "version": 1,
+            "date": "2016-07-13T01:20:19",
+            "path": "results/bundle_wiki_simple-2016-07-13T01:01:59-"
+                    "result.json",
+            "test_id": test_id
+        },
+        "etag": "\"19016fbe653f2f9d5819e4ab21685160\"",
+        "svg_path": "cwr-azure/2/2-log-bundle_wiki_simple-2-result.svg",
+        "parent_build": "",
+        "bundle_name": bundle_name,
+        "date": "2016-07-13T01:20:19",
+        "json_path": "cwr-azure/3/3-log-bundle_wiki_simple-3-result.json",
+        "bundle_file": "",
+        "test_id": test_id,
+        "config": "",
+        "job_name": "cwr-azure"
+    }

--- a/cwrstatus/utils.py
+++ b/cwrstatus/utils.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import uuid
 
+from cwrstatus.config import DATA_PROXY
+
 
 def get_current_utc_time():
     return datetime.utcnow().isoformat()
@@ -8,3 +10,49 @@ def get_current_utc_time():
 
 def generate_test_id():
     return uuid.uuid4().hex
+
+
+def generate_json_results(bundles):
+    results = []
+    for bundle in bundles:
+        outcomes = []
+        test_id = None
+        bundle_name = None
+        for test in bundle:
+            test_id = test.get('test_id')
+            bundle_name = test.get('bundle_name')
+            svg_path, html_path, json_path = _get_artifacts_path(test)
+            outcome = {
+                'html_path': html_path,
+                'json_path': json_path,
+                'svg_path': svg_path,
+                'date': test.get('date'),
+                'results': []
+            }
+            test = test.get('test') or {}
+            for result in test.get('results', []):
+                test_data = {
+                    'provider_name': result.get('provider_name'),
+                    'test_outcome': result.get('test_outcome'),
+                }
+                outcome['results'].append(test_data)
+            outcomes.append(outcome)
+        results.append({
+            'bundle_name': bundle_name,
+            'test_id': test_id,
+            'tests': outcomes,
+        })
+    return results
+
+
+def _get_artifacts_path(test):
+    svg_path = None
+    if test.get('svg_path'):
+        svg_path = '{}/{}'.format(DATA_PROXY, test.get('svg_path'))
+    html_path = None
+    if test.get('html_path'):
+        html_path = '{}/{}'.format(DATA_PROXY, test.get('html_path'))
+    json_path = None
+    if test.get('json_path'):
+        json_path = '{}/{}'.format(DATA_PROXY, test.get('json_path'))
+    return svg_path, html_path, json_path


### PR DESCRIPTION
This PR provides API to access the CWR test result artifacts. Mostly, by adding `.json` at the end of the URL path, it provides json version of the test results. The output have the following format:

```
{
  "bundle_name": "wiki",
  "test_id": "1234",
  "tests": [
    {
      "date": "2016-07-11T07:31:59",
      "html_path": "http://example.com/1",
      "json_path": "http://example.com/2",
      "svg_path": "http://example.com/3",
      "results": [
        {
          "provider_name": "AWS",
          "test_outcome": "All Passed"
        }
      ],
    }
  ]
}
```

- Access to recent test results:  `/recent.json` or `/.json`
      -  Output: http://paste.ubuntu.com/19317921/
- Access to recent test results filtered by bundle name: `/recent/{bundle_name}.json`
      -  Output: http://paste.ubuntu.com/19318053/
- Access to test result by test id: `/test/{test_id}.json`
       - Output: http://paste.ubuntu.com/19318111/